### PR TITLE
 disabling parallel test execution of integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,6 @@
         </dependency>
 
 
-
         <!-- required by scalatest-maven-plugin to generate HTML report -->
 
         <dependency>
@@ -302,7 +301,7 @@
                             </goals>
                             <configuration>
                                 <environmentVariables>
-                                   <HAYSTACK_PROP_KAFKA_PRODUCER_TOPIC>testTopic</HAYSTACK_PROP_KAFKA_PRODUCER_TOPIC>
+                                    <HAYSTACK_PROP_KAFKA_PRODUCER_TOPIC>testTopic</HAYSTACK_PROP_KAFKA_PRODUCER_TOPIC>
                                 </environmentVariables>
                                 <wildcardSuites>${featureTestClasses}</wildcardSuites>
                             </configuration>
@@ -315,6 +314,7 @@
                             </goals>
                             <configuration>
                                 <wildcardSuites>${integrationTestClasses}</wildcardSuites>
+                                <parallel>false</parallel>
                             </configuration>
                         </execution>
                     </executions>

--- a/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/kstream/StreamTopology.scala
+++ b/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/kstream/StreamTopology.scala
@@ -69,14 +69,10 @@ class StreamTopology(projectConfiguration: ProjectConfiguration) extends StateLi
     * @param e throwable object
     */
   override def uncaughtException(t: Thread, e: Throwable): Unit = {
-    LOGGER.error(s"uncaught exception occurred running kafka streams for thread=${
-      t.getName
-    }", e)
+    LOGGER.error(s"uncaught exception occurred running kafka streams for thread=${t.getName}", e)
     // it may happen that uncaught exception gets called by multiple threads at the same time,
     // so we let one of them close the kafka streams and restart it
-    if (closeKafkaStreams()) {
-      start() // start all over again
-    }
+    HealthController.setUnhealthy()
   }
 
   /**
@@ -147,10 +143,10 @@ class StreamTopology(projectConfiguration: ProjectConfiguration) extends StateLi
 
     builder.addSink(
       TOPOLOGY_INTERNAL_SINK_NAME,
-        projectConfiguration.kafkaConfig.producerConfig.topic,
-        new StringSerializer,
-        metricTankSerde.serializer(),
-        TOPOLOGY_AGGREGATOR_PROCESSOR_NAME)
+      projectConfiguration.kafkaConfig.producerConfig.topic,
+      new StringSerializer,
+      metricTankSerde.serializer(),
+      TOPOLOGY_AGGREGATOR_PROCESSOR_NAME)
     builder
   }
 


### PR DESCRIPTION
Disabling parallel test execution for integration tests to fix the flaky integration test issue. 