### PR TITLE
Configurable histogram data

### DIFF
--- a/timeseries-aggregator/src/main/resources/config/base.conf
+++ b/timeseries-aggregator/src/main/resources/config/base.conf
@@ -38,4 +38,10 @@ statestore {
   logging.delay.seconds = 60
   cache.size = 32767
 }
+
 enable.metricpoint.period.replacement = true
+
+histogram {
+  max.value = 2147483647
+  precision = 0
+}

--- a/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/aggregation/metrics/HistogramMetric.scala
+++ b/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/aggregation/metrics/HistogramMetric.scala
@@ -22,6 +22,7 @@ import com.codahale.metrics.Timer
 import com.expedia.www.haystack.commons.entities.Interval.Interval
 import com.expedia.www.haystack.commons.entities.{MetricPoint, MetricType}
 import com.expedia.www.haystack.trends.aggregation.metrics.AggregationType.AggregationType
+import com.expedia.www.haystack.trends.config.ProjectConfiguration
 import com.expedia.www.haystack.trends.kstream.serde.metric.{HistogramMetricSerde, MetricSerde}
 import org.HdrHistogram.Histogram
 
@@ -36,7 +37,7 @@ class HistogramMetric(interval: Interval, histogram: Histogram) extends Metric(i
 
   private val HistogramMetricComputeTimer: Timer = metricRegistry.timer("histogram.metric.compute.time")
 
-  def this(interval: Interval) = this(interval, new Histogram(Int.MaxValue, 0))
+  def this(interval: Interval) = this(interval, new Histogram(ProjectConfiguration.histogramMaxValue, ProjectConfiguration.histogramPrecision))
 
 
   override def mapToMetricPoints(metricName: String, tags: Map[String, String], publishingTimestamp: Long): List[MetricPoint] = {

--- a/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/config/ProjectConfiguration.scala
+++ b/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/config/ProjectConfiguration.scala
@@ -63,6 +63,22 @@ class ProjectConfiguration {
 
   /**
     *
+    * @return max allowable value for a histogram metric
+    */
+  def histogramMaxValue: Int = {
+    config.getInt("histogram.max.value")
+  }
+
+  /**
+    *
+    * @return allowable precision of histogram must be 0 <= value <= 5
+    */
+  def histogramPrecision: Int = {
+    config.getInt("histogram.precision")
+  }
+
+  /**
+    *
     * @return whether period in metric point service & operation name needs to be replaced
     */
   def stateStoreCacheSize: Int = {

--- a/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/kstream/serde/metric/HistogramMetricSerde.scala
+++ b/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/kstream/serde/metric/HistogramMetricSerde.scala
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer
 import com.expedia.www.haystack.commons.entities.Interval
 import com.expedia.www.haystack.commons.entities.Interval.Interval
 import com.expedia.www.haystack.trends.aggregation.metrics.{HistogramMetric, Metric}
+import com.expedia.www.haystack.trends.config.ProjectConfiguration
 import org.HdrHistogram.Histogram
 import org.msgpack.core.MessagePack
 import org.msgpack.value.{Value, ValueFactory}
@@ -39,7 +40,6 @@ object HistogramMetricSerde extends MetricSerde {
     val metric = MessagePack.newDefaultUnpacker(data).unpackValue().asMapValue().map()
     val serializedHistogram = metric.get(ValueFactory.newString(intHistogramKey)).asBinaryValue().asByteArray
     val interval: Interval = Interval.fromName(metric.get(ValueFactory.newString(intervalKey)).asStringValue().toString)
-    new HistogramMetric(interval, Histogram.decodeFromByteBuffer(ByteBuffer.wrap(serializedHistogram), Int.MaxValue))
+    new HistogramMetric(interval, Histogram.decodeFromByteBuffer(ByteBuffer.wrap(serializedHistogram), ProjectConfiguration.histogramMaxValue))
   }
-
 }

--- a/timeseries-aggregator/src/test/scala/com/expedia/www/haystack/trends/feature/tests/aggregation/metrics/HistogramMetricSpec.scala
+++ b/timeseries-aggregator/src/test/scala/com/expedia/www/haystack/trends/feature/tests/aggregation/metrics/HistogramMetricSpec.scala
@@ -81,7 +81,6 @@ class HistogramMetricSpec extends FeatureSpec {
       verifyHistogramMetricValues(histMetricPoints, expectedHistogram)
     }
 
-
     def verifyHistogramMetricValues(resultingMetricPoints: List[MetricPoint], expectedHistogram: IntHistogram) = {
       val resultingMetricPointsMap: Map[String, Float] =
         resultingMetricPoints.map(resultingMetricPoint => resultingMetricPoint.tags(TagKeys.STATS_KEY) -> resultingMetricPoint.value).toMap


### PR DESCRIPTION
@ayansen -> This enables us to change the configuration of the histogram precision. These two knobs give us the precision necessary to show proper durations trends while also allowing us to balance out the memory usage. 