### PR TITLE
Enables error conversion of spans generated with Zipkin instrumentation

### DIFF
--- a/span-timeseries-transformer/src/main/scala/com/expedia/www/haystack/trends/transformer/SpanStatusMetricPointTransformer.scala
+++ b/span-timeseries-transformer/src/main/scala/com/expedia/www/haystack/trends/transformer/SpanStatusMetricPointTransformer.scala
@@ -57,7 +57,7 @@ trait SpanStatusMetricPointTransformer extends MetricPointTransformer {
       if (TagType.BOOL == x.getType) {
         return x.getVBool
       } else if (TagType.STRING == x.getType) {
-        return "true".equalsIgnoreCase(x.getVStr)
+        return !"false".equalsIgnoreCase(x.getVStr)
       }
       return true
     })

--- a/span-timeseries-transformer/src/test/scala/com/expedia/www/haystack/trends/feature/tests/transformer/SpanStatusMetricPointTransformerSpec.scala
+++ b/span-timeseries-transformer/src/test/scala/com/expedia/www/haystack/trends/feature/tests/transformer/SpanStatusMetricPointTransformerSpec.scala
@@ -112,6 +112,25 @@ class SpanStatusMetricPointTransformerSpec extends FeatureSpec with SpanStatusMe
       metricPoints(0).metric shouldEqual FAILURE_METRIC_NAME
     }
 
+    scenario("should have a failure-span metricPoint if the error tag not a false string") {
+      Given("a failure span object")
+      val operationName = "testSpan"
+      val serviceName = "testService"
+      val duration = System.currentTimeMillis
+      val span = Span.newBuilder()
+        .setDuration(duration)
+        .setOperationName(operationName)
+        .setServiceName(serviceName)
+        .addTags(Tag.newBuilder().setKey(TagKeys.ERROR_KEY).setVStr("500"))
+        .build()
+
+      When("metricPoint is created using transformer")
+      val metricPoints = mapSpan(span, true)
+
+      Then("metric name should be failure-spans")
+      metricPoints(0).metric shouldEqual FAILURE_METRIC_NAME
+    }
+
     scenario("should have a failure-span metricPoint if the error tag exists but is not a boolean or string") {
       Given("a failure span object")
       val operationName = "testSpan"


### PR DESCRIPTION
Zipkin's format of the "error" tag was designed to allow for cheaper
indexing and filtering for the common case where the error has a short
message description.

FWIW, we advised OpenTracing about their convention of a boolean
encouraging people to write "error"=false redundantly, and that having
to specify an error with two commands was less efficient both in process
and in indexing, but the leaders proceeded anyway.

Back to the point.. In Zipkin (and perhaps other non-opentracing)
instrumentation, presence of a tag named "error" (implicitly of type
string) means an error occurred. Other tags can also be present, but for
example when we are aggregating, you only need to filter on spans who
have any tag named "error".

It is my guess that Haystack intends to be useful beyond sites who
exclusively link to OpenTracing to produce tracing data, especially as
there's almost no logic in the pipeline that has anything to do with
OpenTracing. However, there is this one spot.. basically the way error
processing works it expects the exact boolean conventions which will
definitely not work with a lot of instrumentation out there.

The following change makes a very small adjustment which will allow this
to work with ad-hoc or non OpenTracing instrumentation. It seems an easy
portability win and keeps the metrics aggregation nicely decoupled in a
way that could work out of box with mechanical conversion upstream.