### PR TITLE
Fix ArrayIndexOutOfBoundException when there is no data in histogram;

### DIFF
--- a/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/aggregation/metrics/HistogramMetric.scala
+++ b/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/aggregation/metrics/HistogramMetric.scala
@@ -45,16 +45,24 @@ class HistogramMetric(interval: Interval, histogram: Histogram) extends Metric(i
     val result = Map(
       MEAN -> histogram.getMean.toLong,
       MIN -> histogram.getMinValue,
-      PERCENTILE_95 -> histogram.getValueAtPercentile(95),
-      PERCENTILE_99 -> histogram.getValueAtPercentile(99),
+      PERCENTILE_95 -> getHistogramForPercentile(histogram, 95.0),
+      PERCENTILE_99 -> getHistogramForPercentile(histogram, 99.0),
       STDDEV -> histogram.getStdDeviation.toLong,
-      MEDIAN -> histogram.getValueAtPercentile(50),
+      MEDIAN -> getHistogramForPercentile(histogram, 50.0),
       MAX -> histogram.getMaxValue
     ).map {
       case (stat, value) =>
         MetricPoint(metricName, MetricType.Gauge, appendTags(tags, interval, stat), value, publishingTimestamp)
     }
     result.toList
+  }
+
+  private def getHistogramForPercentile(histogram: Histogram, percentile: Double): Long = {
+    try {
+      histogram.getValueAtPercentile(percentile)
+    } catch {
+      case _: ArrayIndexOutOfBoundsException => 0L
+    }
   }
 
   def getRunningHistogram: Histogram = {


### PR DESCRIPTION
seen in Test
java.lang.ArrayIndexOutOfBoundsException: percentile value not found in range
at org.HdrHistogram.AbstractHistogram.getValueAtPercentile(AbstractHistogram.java:761)
at com.expedia.www.haystack.trends.aggregation.metrics.HistogramMetric.mapToMetricPoints(HistogramMetric.scala:48)