### PR TITLE
Use G1 garbage collection, turn on GC logging, collect GC metrics.

### DIFF
--- a/span-timeseries-transformer/build/docker/jmxtrans-agent.xml
+++ b/span-timeseries-transformer/build/docker/jmxtrans-agent.xml
@@ -5,10 +5,28 @@
         <query objectName="java.lang:type=Memory" attribute="HeapMemoryUsage" key="committed" resultAlias="jvm.heapMemoryUsage.committed"/>
         <query objectName="java.lang:type=Memory" attribute="NonHeapMemoryUsage" key="used" resultAlias="jvm.nonHeapMemoryUsage.used"/>
         <query objectName="java.lang:type=Memory" attribute="NonHeapMemoryUsage" key="committed" resultAlias="jvm.nonHeapMemoryUsage.committed"/>
-        <!--<query objectName="java.lang:type=GarbageCollector,name=ParNew" resultAlias="gc.young.#attribute#"/>-->
-        <!--<query objectName="java.lang:type=GarbageCollector,name=ConcurrentMarkSweep" resultAlias="gc.old.#attribute#"/>-->
-        <!--<query objectName="java.lang:type=ClassLoading" attribute="LoadedClassCount" resultAlias="jvm.loadedClasses"/>-->
-        <!--<query objectName="java.lang:type=Threading" attribute="ThreadCount" resultAlias="jvm.thread"/>-->
+
+        <!-- useG1GC metrics -->
+<!--
+        <query objectName="java.lang:type=MemoryPool,name=G1 Eden Space" attribute="Usage" key="used"
+               resultAlias="jvm.g1EdenSpace.used" />
+        <query objectName="java.lang:type=MemoryPool,name=G1 Eden Space" attribute="Usage" key="max"
+               resultAlias="jvm.g1EdenSpace.max" />
+-->
+        <query objectName="java.lang:type=MemoryPool,name=G1 Old Gen" attribute="Usage" key="used"
+               resultAlias="jvm.g1OldGen.used" />
+        <query objectName="java.lang:type=MemoryPool,name=G1 Old Gen" attribute="Usage" key="max"
+               resultAlias="jvm.g1OldGen.max" />
+
+        <query objectName="java.lang:type=MemoryPool,name=G1 Survivor Space" attribute="Usage" key="max"
+               resultAlias="jvm.g1SurvivorSpace.max" />
+        <query objectName="java.lang:type=MemoryPool,name=G1 Survivor Space" attribute="Usage" key="used"
+               resultAlias="jvm.g1SurvivorSpace.used" />
+
+        <query objectName="java.lang:type=GarbageCollector" attribute="LastGcInfo" key="duration"
+               resultAlias="jvm.gc.duration" />
+        <query objectName="java.lang:type=GarbageCollector" attribute="CollectionTime"
+               resultAlias="jvm.gc.collection.time" />
 
         <!-- kafka producer metrics -->
         <query objectName="kafka.producer:type=producer-metrics,client-id=*" attribute="record-send-rate"

--- a/span-timeseries-transformer/build/docker/start-app.sh
+++ b/span-timeseries-transformer/build/docker/start-app.sh
@@ -6,8 +6,13 @@
 set -e
 JAVA_OPTS="${JAVA_OPTS} \
 -javaagent:${APP_HOME}/${JMXTRANS_AGENT}.jar=${APP_HOME}/jmxtrans-agent.xml \
--XX:+UseConcMarkSweepGC \
--XX:+UseParNewGC \
+-XX:+UseG1GC \
+-Xloggc:/var/log/gc.log \
+-XX:+PrintGCDetails \
+-XX:+PrintGCDateStamps \
+-XX:+UseGCLogFileRotation \
+-XX:NumberOfGCLogFiles=5 \
+-XX:GCLogFileSize=2M \
 -Xmx${JAVA_XMX} \
 -Xms${JAVA_XMS} \
 -Dcom.sun.management.jmxremote.authenticate=false \

--- a/timeseries-aggregator/build/docker/jmxtrans-agent.xml
+++ b/timeseries-aggregator/build/docker/jmxtrans-agent.xml
@@ -10,10 +10,28 @@
                resultAlias="jvm.nonHeapMemoryUsage.used"/>
         <query objectName="java.lang:type=Memory" attribute="NonHeapMemoryUsage" key="committed"
                resultAlias="jvm.nonHeapMemoryUsage.committed"/>
-        <!--<query objectName="java.lang:type=GarbageCollector,name=ParNew" resultAlias="gc.young.#attribute#"/>-->
-        <!--<query objectName="java.lang:type=GarbageCollector,name=ConcurrentMarkSweep" resultAlias="gc.old.#attribute#"/>-->
-        <!--<query objectName="java.lang:type=ClassLoading" attribute="LoadedClassCount" resultAlias="jvm.loadedClasses"/>-->
-        <!--<query objectName="java.lang:type=Threading" attribute="ThreadCount" resultAlias="jvm.thread"/>-->
+
+        <!-- useG1GC metrics -->
+<!--
+        <query objectName="java.lang:type=MemoryPool,name=G1 Eden Space" attribute="Usage" key="used"
+               resultAlias="jvm.g1EdenSpace.used" />
+        <query objectName="java.lang:type=MemoryPool,name=G1 Eden Space" attribute="Usage" key="max"
+               resultAlias="jvm.g1EdenSpace.max" />
+-->
+        <query objectName="java.lang:type=MemoryPool,name=G1 Old Gen" attribute="Usage" key="used"
+               resultAlias="jvm.g1OldGen.used" />
+        <query objectName="java.lang:type=MemoryPool,name=G1 Old Gen" attribute="Usage" key="max"
+               resultAlias="jvm.g1OldGen.max" />
+
+        <query objectName="java.lang:type=MemoryPool,name=G1 Survivor Space" attribute="Usage" key="max"
+               resultAlias="jvm.g1SurvivorSpace.max" />
+        <query objectName="java.lang:type=MemoryPool,name=G1 Survivor Space" attribute="Usage" key="used"
+               resultAlias="jvm.g1SurvivorSpace.used" />
+
+        <query objectName="java.lang:type=GarbageCollector" attribute="LastGcInfo" key="duration"
+               resultAlias="jvm.gc.duration" />
+        <query objectName="java.lang:type=GarbageCollector" attribute="CollectionTime"
+               resultAlias="jvm.gc.collection.time" />
 
         <query objectName="kafka.producer:type=producer-metrics,client-id=*" attribute="record-send-rate" resultAlias="kafka-producer-%client-id%.record-send.rate"/>
         <query objectName="kafka.producer:type=producer-metrics,client-id=*" attribute="buffer-exhausted-rate" resultAlias="kafka-producer-%client-id%.buffer-exhausted.rate"/>

--- a/timeseries-aggregator/build/docker/start-app.sh
+++ b/timeseries-aggregator/build/docker/start-app.sh
@@ -6,8 +6,13 @@
 set -e
 JAVA_OPTS="${JAVA_OPTS} \
 -javaagent:${APP_HOME}/${JMXTRANS_AGENT}.jar=${APP_HOME}/jmxtrans-agent.xml \
--XX:+UseConcMarkSweepGC \
--XX:+UseParNewGC \
+-XX:+UseG1GC \
+-Xloggc:/var/log/gc.log \
+-XX:+PrintGCDetails \
+-XX:+PrintGCDateStamps \
+-XX:+UseGCLogFileRotation \
+-XX:NumberOfGCLogFiles=5 \
+-XX:GCLogFileSize=2M \
 -Xmx${JAVA_XMX} \
 -Xms${JAVA_XMS} \
 -Dapplication.name=${APP_NAME} \


### PR DESCRIPTION
We're hoping to learn more about why hosts occasionally see large
Kafka lag, in a spiky pattern. See
https://github.com/ExpediaDotCom/haystack-trends/issues/157.