### PR TITLE
Add custom timeInTopic metric to timeseries-aggregator

### DIFF
--- a/timeseries-aggregator/build/docker/jmxtrans-agent.xml
+++ b/timeseries-aggregator/build/docker/jmxtrans-agent.xml
@@ -74,6 +74,8 @@
                resultAlias="metricpoint.ser.success.#attribute#"/>
         <query objectName="metrics:name=metricpoints.disordered" attributes="OneMinuteRate,MeanRate"
                resultAlias="metricpoint.disordered.#attribute#"/>
+        <query objectName="metrics:name=metricpoints.timeInTopic" attributes="95thPercentile,99thPercentile,999thPercentile,Count,Max,Mean,Median,Mean"
+               resultAlias="metricpoint.timeInTopic.#attribute#"/>
         <query objectName="metrics:name=metricpoints.compute.failure" attributes="OneMinuteRate,MeanRate"
                resultAlias="metricpoint.compute.failure.#attribute#"/>
         <query objectName="metrics:name=metricprocessor.invalid" attributes="OneMinuteRate,MeanRate"

--- a/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/aggregation/WindowedMetric.scala
+++ b/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/aggregation/WindowedMetric.scala
@@ -18,7 +18,7 @@
 
 package com.expedia.www.haystack.trends.aggregation
 
-import com.codahale.metrics.Meter
+import com.codahale.metrics.{Histogram, Meter}
 import com.expedia.metrics.MetricData
 import com.expedia.www.haystack.commons.entities.Interval.Interval
 import com.expedia.www.haystack.commons.metrics.MetricsSupport
@@ -38,6 +38,7 @@ import scala.util.Try
 class WindowedMetric private(var windowedMetricsMap: mutable.TreeMap[TimeWindow, Metric], metricFactory: MetricFactory, numberOfWatermarkedWindows: Int, interval: Interval) extends MetricsSupport {
 
   private val disorderedMetricPointMeter: Meter = metricRegistry.meter("metricpoints.disordered")
+  private val timeInTopicMetricPointHistograma: Histogram = metricRegistry.histogram("metricpoints.timeInTopic")
   private var computedMetrics = List[(Long, Metric)]()
   private val LOGGER = LoggerFactory.getLogger(this.getClass)
 
@@ -52,6 +53,8 @@ class WindowedMetric private(var windowedMetricsMap: mutable.TreeMap[TimeWindow,
     * @param incomingMetricData - incoming metric data
     */
   def compute(incomingMetricData: MetricData): Unit = {
+    timeInTopicMetricPointHistograma.update(incomingMetricData.getTimestamp - System.currentTimeMillis())
+
     val incomingMetricPointTimeWindow = TimeWindow.apply(incomingMetricData.getTimestamp, interval)
 
     val matchedWindowedMetric = windowedMetricsMap.get(incomingMetricPointTimeWindow)

--- a/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/aggregation/WindowedMetric.scala
+++ b/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/aggregation/WindowedMetric.scala
@@ -38,7 +38,7 @@ import scala.util.Try
 class WindowedMetric private(var windowedMetricsMap: mutable.TreeMap[TimeWindow, Metric], metricFactory: MetricFactory, numberOfWatermarkedWindows: Int, interval: Interval) extends MetricsSupport {
 
   private val disorderedMetricPointMeter: Meter = metricRegistry.meter("metricpoints.disordered")
-  private val timeInTopicMetricPointHistograma: Histogram = metricRegistry.histogram("metricpoints.timeInTopic")
+  private val timeInTopicMetricPointHistogram: Histogram = metricRegistry.histogram("metricpoints.timeInTopic")
   private var computedMetrics = List[(Long, Metric)]()
   private val LOGGER = LoggerFactory.getLogger(this.getClass)
 
@@ -53,7 +53,7 @@ class WindowedMetric private(var windowedMetricsMap: mutable.TreeMap[TimeWindow,
     * @param incomingMetricData - incoming metric data
     */
   def compute(incomingMetricData: MetricData): Unit = {
-    timeInTopicMetricPointHistograma.update(incomingMetricData.getTimestamp - System.currentTimeMillis())
+    timeInTopicMetricPointHistogram.update(incomingMetricData.getTimestamp - System.currentTimeMillis())
 
     val incomingMetricPointTimeWindow = TimeWindow.apply(incomingMetricData.getTimestamp, interval)
 

--- a/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/aggregation/WindowedMetric.scala
+++ b/timeseries-aggregator/src/main/scala/com/expedia/www/haystack/trends/aggregation/WindowedMetric.scala
@@ -53,7 +53,7 @@ class WindowedMetric private(var windowedMetricsMap: mutable.TreeMap[TimeWindow,
     * @param incomingMetricData - incoming metric data
     */
   def compute(incomingMetricData: MetricData): Unit = {
-    timeInTopicMetricPointHistogram.update(incomingMetricData.getTimestamp - System.currentTimeMillis())
+    timeInTopicMetricPointHistogram.update(incomingMetricData.getTimestamp() - System.currentTimeMillis())
 
     val incomingMetricPointTimeWindow = TimeWindow.apply(incomingMetricData.getTimestamp, interval)
 


### PR DESCRIPTION
This PR adds a new metric that measures the amount of time between a given span's creation timestamp and the point at which it is consumed as part of trends creation.

Our goal is to be able to demonstrate the amount of time between the time an app submits a trace and the time it takes to generate trends off of it is underneath a certain upper bound.